### PR TITLE
Upgrade to target .NET 6.0

### DIFF
--- a/MDRPC/MDRPC.csproj
+++ b/MDRPC/MDRPC.csproj
@@ -1,78 +1,42 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C3121DB3-33AE-4CC2-A3A4-740D945BD33C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MDRPC</RootNamespace>
-    <AssemblyName>MDRPC</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>embedded</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\publish\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DebugSymbols>true</DebugSymbols>
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
+  <Target Name="CopyDLLs" AfterTargets="Build">
+    <Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="$(MD_NET6_DIRECTORY)\Mods" />
+    <Message Text="Copied DLL -&gt; $(MD_NET6_DIRECTORY)\Mods\$(ProjectName).dll" Importance="High" />
+  </Target>
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <Private>False</Private>
+    <Reference Include="0Harmony">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\net6\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <Private>False</Private>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\Il2CppAssemblies\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Il2Cppmscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <Private>False</Private>
+    <Reference Include="Il2CppInterop.Runtime">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Il2Cppmscorlib">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\Il2CppAssemblies\Il2Cppmscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="Il2CppSystem">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\Il2CppAssemblies\Il2CppSystem.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <Private>False</Private>
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\net6\MelonLoader.dll</HintPath>
     </Reference>
-    <Reference Include="Sirenix.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <Private>False</Private>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="UnhollowerBaseLib, Version=0.4.18.0, Culture=neutral, PublicKeyToken=null">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <Private>False</Private>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(MD_NET6_DIRECTORY)\MelonLoader\Il2CppAssemblies\Il2CppSirenix.Serialization.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Models\ActivityModel.cs" />
-    <Compile Include="Models\CharacterModel.cs" />
-    <Compile Include="Models\ElfinModel.cs" />
-    <Compile Include="Patches\HideBmsCheckPatch.cs" />
-    <Compile Include="Properties\Global.cs" />
-    <Compile Include="Mod.cs" />
-    <Compile Include="Models\SongLevelModel.cs" />
-    <Compile Include="Patches\DiscordPatch.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\BuildInfo.cs" />
-    <Compile Include="Properties\Constants.cs" />
-    <Compile Include="Utils\Extensions.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/MDRPC/Models/ActivityModel.cs
+++ b/MDRPC/Models/ActivityModel.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Linq;
-using MDRPC.Patches;
-using Assets.Scripts.PeroTools.Commons;
-using Assets.Scripts.PeroTools.Nice.Datas;
+﻿using MDRPC.Patches;
+using Il2CppAssets.Scripts.PeroTools.Nice.Datas;
+using Il2CppAssets.Scripts.PeroTools.Commons;
 
 namespace MDRPC.Models
 {

--- a/MDRPC/Models/CharacterModel.cs
+++ b/MDRPC/Models/CharacterModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using PeroPeroGames.GlobalDefines;
+﻿using Il2CppPeroPeroGames.GlobalDefines;
 
 namespace MDRPC.Models
 {

--- a/MDRPC/Models/ElfinModel.cs
+++ b/MDRPC/Models/ElfinModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using PeroPeroGames.GlobalDefines;
+﻿using Il2CppPeroPeroGames.GlobalDefines;
 
 namespace MDRPC.Models
 {

--- a/MDRPC/Models/SongLevelModel.cs
+++ b/MDRPC/Models/SongLevelModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using PeroPeroGames.GlobalDefines;
+﻿using Il2CppPeroPeroGames.GlobalDefines;
 
 namespace MDRPC.Models
 {

--- a/MDRPC/Patches/DiscordPatch.cs
+++ b/MDRPC/Patches/DiscordPatch.cs
@@ -118,10 +118,14 @@ namespace MDRPC.Patches
             activity.Details = activityModel.GetDetails();
             activity.State = activityModel.GetState();
             activity.Assets = Extensions.CreateValueType<ActivityAssets>();
-            activity.Assets.LargeImage = activityModel.GetLargeImage();
-            activity.Assets.LargeText = activityModel.GetLargeImageText();
-            activity.Assets.SmallImage = activityModel.GetSmallImage();
-            activity.Assets.SmallText = activityModel.GetSmallImageText();
+
+            var assets = Extensions.CreateValueType<ActivityAssets>();
+            assets.LargeImage = activityModel.GetLargeImage();
+            assets.LargeText = activityModel.GetLargeImageText();
+            assets.SmallImage = activityModel.GetSmallImage();
+            assets.SmallText = activityModel.GetSmallImageText();
+            activity.Assets = assets;
+
             activity.Timestamps = new ActivityTimestamps
             {
                 Start = timePlayed

--- a/MDRPC/Patches/DiscordPatch.cs
+++ b/MDRPC/Patches/DiscordPatch.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using Discord;
+﻿using System.Drawing;
 using HarmonyLib;
 using MelonLoader;
 using MDRPC.Models;
+using Il2CppDiscord;
+using Il2Cpp;
+using Il2CppInterop.Runtime;
 
 namespace MDRPC.Patches
 {
@@ -92,7 +94,7 @@ namespace MDRPC.Patches
                 Dispose();
 
                 // Reinit Discord Client
-                DiscordPatch.manager.m_Discord = new Discord.Discord(Constants.Discord.ClientId, 1UL);
+                DiscordPatch.manager.m_Discord = new Discord(Constants.Discord.ClientId, 1UL);
 
                 if (DiscordPatch.manager.m_Discord.isInit == Result.Ok)
                 {
@@ -111,21 +113,18 @@ namespace MDRPC.Patches
 
         private static void UpdateActivity()
         {
-            activity = new Activity
+            // Requires a workaround to create ValueType objects
+            activity = Extensions.CreateValueType<Activity>();
+            activity.Details = activityModel.GetDetails();
+            activity.State = activityModel.GetState();
+            activity.Assets = Extensions.CreateValueType<ActivityAssets>();
+            activity.Assets.LargeImage = activityModel.GetLargeImage();
+            activity.Assets.LargeText = activityModel.GetLargeImageText();
+            activity.Assets.SmallImage = activityModel.GetSmallImage();
+            activity.Assets.SmallText = activityModel.GetSmallImageText();
+            activity.Timestamps = new ActivityTimestamps
             {
-                Details = activityModel.GetDetails(),
-                State = activityModel.GetState(),
-                Assets = new ActivityAssets()
-                {
-                    LargeImage = activityModel.GetLargeImage(),
-                    LargeText = activityModel.GetLargeImageText(),
-                    SmallImage = activityModel.GetSmallImage(),
-                    SmallText = activityModel.GetSmallImageText(),
-                },
-                Timestamps = new ActivityTimestamps()
-                {
-                    Start = timePlayed
-                },
+                Start = timePlayed
             };
         }
 

--- a/MDRPC/Patches/HideBmsCheckPatch.cs
+++ b/MDRPC/Patches/HideBmsCheckPatch.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
-using Assets.Scripts.Database;
+using Il2Cpp;
+using Il2CppAssets.Scripts.Database;
 
 namespace MDRPC.Patches
 {

--- a/MDRPC/Utils/Extensions.cs
+++ b/MDRPC/Utils/Extensions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Assets.Scripts.PeroTools.Nice.Interface;
+﻿using Il2CppAssets.Scripts.PeroTools.Nice.Interface;
+using Il2CppInterop.Runtime;
 
 namespace MDRPC
 {
@@ -13,6 +13,17 @@ namespace MDRPC
         public static T Get<T>(this IVariable variable)
         {
             return VariableUtils.GetResult<T>(variable);
+        }
+
+        /// <summary>
+        /// Workaround to create ValueType objects with Il2CppInterop
+        /// </summary>
+        /// <typeparam name="T">Type to generate</typeparam>
+        /// <returns>Properly initialized ValueType object</returns>
+        public static T CreateValueType<T>()
+        {
+            return (T)Activator.CreateInstance(typeof(T),
+                IL2CPP.il2cpp_object_new(Il2CppClassPointerStore<T>.NativeClassPtr));
         }
     }
 }


### PR DESCRIPTION
I upgraded the mod to target .NET 6.0 which is required for MelonLoader v0.6+.
Since Muse Dash v3.12.1 requires MelonLoader v0.6 or above, I wanted to retarget this mod.

I also saw some places for code optimization, but I wanted to maintain your style for this retarget. You can let me know if you're also interested in some optimizations and I can push those. Just wanted to keep this vanilla.